### PR TITLE
Fix solution:

### DIFF
--- a/src/main/java/simpledb/storage/lock/PageTransactionLocker.java
+++ b/src/main/java/simpledb/storage/lock/PageTransactionLocker.java
@@ -43,7 +43,8 @@ public class PageTransactionLocker implements Locker {
                 // lock has been acquired, but not same with transaction Id given by context (above logic)
                 for (;;) {
                     if (timeoutNano - System.nanoTime() <= 0) {
-                        throw new InterruptedException("timed out: " + context);
+                        System.err.println("timed out: " + context);
+                        return false;
                     }
                     if (lock.get()) {
                         Thread.sleep(1);
@@ -68,7 +69,8 @@ public class PageTransactionLocker implements Locker {
                 }
                 for (;;) {
                     if (timeoutNano - System.nanoTime() <= 0) {
-                        throw new InterruptedException("timed out: " + context);
+                        System.err.println("timed out: " + context);
+                        return false;
                     }
                     if (lock.get() || !isLockUpgradable(context.getTransactionId())) {
                         Thread.sleep(1);

--- a/src/main/java/simpledb/storage/page/DefaultPageManager.java
+++ b/src/main/java/simpledb/storage/page/DefaultPageManager.java
@@ -121,8 +121,17 @@ public class DefaultPageManager implements PageManager {
         }
     }
 
+    /**
+     * if the page is dirty (holds a transactionId), we cannot remove it as it's not able to flush it yet (transaction not finished)
+     */
     private void removeLast() {
         ListNode last = tail.prev;
+        while (last != head && last.page.isDirty() != null) {
+            last = last.prev;
+        }
+        if (last == null) {
+            return;
+        }
         removeNode(last);
         pages.remove(last.page.getId());
     }


### PR DESCRIPTION
1. because we remove a page(memory) from page manager during transaction(LRU size over capacity), once we continue to read the page, the former write operations lost.
2. so we need to, loop the LRU list from end to begin until we find a non-dirty page, to remove it, otherwise, we stop and won't remove any pages